### PR TITLE
Fix link to current live version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ publishes the bleeding edge version to github.io can look something like
 `pub run -c test --run-skipped && peanut && git push origin --set-upstream gh-pages`.
 
 There is a shorthand for uploading the current version to 
-[https://egamebook.com/vermin](). First, ensure everything is built 
-(`egamebook build`, `dart tool/build.dart`, then `pub build`). 
-Second, make sure the current version runs well 
+[https://egamebook.com/vermin](https://egamebook.com/vermin). First, ensure
+everything is built  (`egamebook build`, `dart tool/build.dart`, then
+`pub build`). Second, make sure the current version runs well 
 (`pub run -c test --run-skipped`). 
 Third, run `./build_ifcomp_submission.sh` to copy the build over to 
 `../egamebook/docs/site` (this assumes `egamebook` directory is a sibling


### PR DESCRIPTION
Most parsers don't understand the syntax you've used: https://johnmacfarlane.net/babelmark2/?text=%5Bhttp%3A%2F%2Fexample.org%2F%5D()

Not sure if I should have wrapped the text or not!

Oh, and thank you for this great idea and great execution.